### PR TITLE
Make tests pass on CI

### DIFF
--- a/lib/DataFileUtil/DataFileUtilImpl.py
+++ b/lib/DataFileUtil/DataFileUtilImpl.py
@@ -825,8 +825,7 @@ archiving.
         source_id = params.get('shock_id')
         if not source_id:
             raise ValueError('Must provide shock ID')
-        res = requests.get(self.shock_url + '/node/' + source_id +
-                           '/acl/owner/?verbosity=full',
+        res = requests.get(self.shock_url + '/node/' + source_id + '/acl/?verbosity=full',
                            headers=header, allow_redirects=True)
         self.check_shock_response(
             res, 'Error getting ACLs for Shock node {}: '.format(source_id))


### PR DESCRIPTION
Per admins Shock is the same on CI and appdev but one of the ownership
tests fails on CI (config difference?). Pulling back the entire acls
list rather than just the owner allows the test to pass.