### PR TITLE
manually re-compile server to add new methods

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,6 +26,7 @@ compile:
 		--javasrc src \
 		--java \
 		--pyimplname $(SERVICE_CAPS).$(SERVICE_CAPS)Impl;
+		# this is commented out until https://github.com/kbase/kb_sdk/pull/227 is available in all catalog instances
 		#--pysrvname $(SERVICE_CAPS).$(SERVICE_CAPS)Server # add slash when restore
 	kb-sdk compile --html $(SPEC_FILE)
 

--- a/kbase.yml
+++ b/kbase.yml
@@ -8,7 +8,7 @@ service-language:
     python
 
 module-version:
-    0.0.13
+    0.0.14
 
 owners:
     [rsutormin, msneddon, gaprice, scanon]

--- a/lib/DataFileUtil/DataFileUtilServer.py
+++ b/lib/DataFileUtil/DataFileUtilServer.py
@@ -385,6 +385,14 @@ class Application(object):
                              name='DataFileUtil.versions',
                              types=[])
         self.method_authentication['DataFileUtil.versions'] = 'required'  # noqa
+        self.rpc_service.add(impl_DataFileUtil.download_staging_file,
+                             name='DataFileUtil.download_staging_file',
+                             types=[dict])
+        self.method_authentication['DataFileUtil.download_staging_file'] = 'required'  # noqa
+        self.rpc_service.add(impl_DataFileUtil.download_web_file,
+                             name='DataFileUtil.download_web_file',
+                             types=[dict])
+        self.method_authentication['DataFileUtil.download_web_file'] = 'required'  # noqa
         self.rpc_service.add(impl_DataFileUtil.status,
                              name='DataFileUtil.status',
                              types=[dict])


### PR DESCRIPTION
KBase SDK version 1.0.11 (commit
6181171cc19757a843211825aa584ca65caca5e2)

(note this version is locally modified and has the fix from
https://github.com/kbase/kb_sdk/pull/227)