### PR TITLE
Fix for BZ2 multistream files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 test_local
 sdk.cfg
 /run_local/
+*.py.bak-*

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,6 +27,7 @@ RUN sudo apt-get update \
     && yes '' | sudo apt-get -y upgrade openssl
 
 RUN sudo apt-get install pigz
+RUN pip install bz2file
 
 COPY ./ /kb/module
 RUN mkdir -p /kb/module/work

--- a/kbase.yml
+++ b/kbase.yml
@@ -8,7 +8,7 @@ service-language:
     python
 
 module-version:
-    0.0.19
+    0.0.20
 
 owners:
     [rsutormin, msneddon, gaprice, scanon]

--- a/lib/DataFileUtil/DataFileUtilImpl.py
+++ b/lib/DataFileUtil/DataFileUtilImpl.py
@@ -14,7 +14,7 @@ from Workspace.baseclient import ServerError as WorkspaceError
 import semver
 import magic
 import tempfile
-import bz2  # @UnresolvedImport no idea why PyDev is complaining about this
+import bz2file  # @UnresolvedImport no idea why PyDev is complaining about this
 import tarfile
 import zipfile
 import errno
@@ -279,7 +279,7 @@ archiving.
         # source
         if t in ['application/' + x for x in
                  'x-bzip', 'x-bzip2', 'bzip', 'bzip2']:
-            return self._decompress(bz2.BZ2File, file_path, unpack)
+            return self._decompress(bz2file.BZ2File, file_path, unpack)
 
         self._unarchive(file_path, unpack, t)
         return file_path


### PR DESCRIPTION
Drop in replacement for the built in python 2 bz lib that can handle multistream bz2 files similar to the python 3 version.