### PR TITLE
fix hs2 related tests

### DIFF
--- a/dependencies.json
+++ b/dependencies.json
@@ -1,7 +1,7 @@
 [ {
   "module_name" : "AbstractHandle",
   "type" : "core",
-  "file_path" : "https://raw.githubusercontent.com/kbase/handle_service/master/handle_service.spec"
+  "file_path" : "https://raw.githubusercontent.com/kbase/handle_service2/develop/handle_service.spec"
 }, {
   "module_name" : "Workspace",
   "type" : "core",

--- a/kbase.yml
+++ b/kbase.yml
@@ -8,7 +8,7 @@ service-language:
     python
 
 module-version:
-    0.1.1
+    0.1.2
 
 owners:
     [rsutormin, msneddon, gaprice, scanon, tgu2]

--- a/lib/DataFileUtil/DataFileUtilImpl.py
+++ b/lib/DataFileUtil/DataFileUtilImpl.py
@@ -56,7 +56,7 @@ archiving.
     # state. A method could easily clobber the state set by another while
     # the latter method is running.
     ######################################### noqa
-    VERSION = "0.1.1"
+    VERSION = "0.1.2"
     GIT_URL = "https://github.com/mrcreosote/DataFileUtil"
     GIT_COMMIT_HASH = "f816c1d3ab84c9cee6a83b3d7200a44b4de112ef"
 

--- a/lib/installed_clients/AbstractHandleClient.py
+++ b/lib/installed_clients/AbstractHandleClient.py
@@ -33,229 +33,32 @@ class AbstractHandle(object):
             trust_all_ssl_certificates=trust_all_ssl_certificates,
             auth_svc=auth_svc)
 
-    def new_handle(self, context=None):
+    def persist_handle(self, handle, context=None):
         """
-        The new_handle function returns a Handle object with a url and a
-        node id. The new_handle function invokes the localize_handle
-        method first to set the url and then invokes the initialize_handle
-        function to get an ID.
-        :returns: instance of type "Handle" -> structure: parameter "hid" of
-           type "HandleId" (Handle provides a unique reference that enables
-           access to the data files through functions provided as part of the
-           HandleService. In the case of using shock, the id is the node id.
-           In the case of using shock the value of type is shock. In the
-           future these values should enumerated. The value of url is the
-           http address of the shock server, including the protocol (http or
-           https) and if necessary the port. The values of remote_md5 and
-           remote_sha1 are those computed on the file in the remote data
-           store. These can be used to verify uploads and downloads.),
-           parameter "file_name" of String, parameter "id" of type "NodeId",
-           parameter "type" of String, parameter "url" of String, parameter
-           "remote_md5" of String, parameter "remote_sha1" of String
-        """
-        return self._client.call_method('AbstractHandle.new_handle',
-                                        [], self._service_ver, context)
-
-    def localize_handle(self, h1, service_name, context=None):
-        """
-        The localize_handle function attempts to locate a shock server near
-        the service. The localize_handle function must be called before the
-                   Handle is initialized becuase when the handle is initialized, it is
-                   given a node id that maps to the shock server where the node was
-                   created. This function should not be called directly.
-        :param h1: instance of type "Handle" -> structure: parameter "hid" of
-           type "HandleId" (Handle provides a unique reference that enables
-           access to the data files through functions provided as part of the
-           HandleService. In the case of using shock, the id is the node id.
-           In the case of using shock the value of type is shock. In the
-           future these values should enumerated. The value of url is the
-           http address of the shock server, including the protocol (http or
-           https) and if necessary the port. The values of remote_md5 and
-           remote_sha1 are those computed on the file in the remote data
-           store. These can be used to verify uploads and downloads.),
-           parameter "file_name" of String, parameter "id" of type "NodeId",
-           parameter "type" of String, parameter "url" of String, parameter
-           "remote_md5" of String, parameter "remote_sha1" of String
-        :param service_name: instance of String
-        :returns: instance of type "Handle" -> structure: parameter "hid" of
-           type "HandleId" (Handle provides a unique reference that enables
-           access to the data files through functions provided as part of the
-           HandleService. In the case of using shock, the id is the node id.
-           In the case of using shock the value of type is shock. In the
-           future these values should enumerated. The value of url is the
-           http address of the shock server, including the protocol (http or
-           https) and if necessary the port. The values of remote_md5 and
-           remote_sha1 are those computed on the file in the remote data
-           store. These can be used to verify uploads and downloads.),
-           parameter "file_name" of String, parameter "id" of type "NodeId",
-           parameter "type" of String, parameter "url" of String, parameter
-           "remote_md5" of String, parameter "remote_sha1" of String
-        """
-        return self._client.call_method('AbstractHandle.localize_handle',
-                                        [h1, service_name], self._service_ver, context)
-
-    def initialize_handle(self, h1, context=None):
-        """
-        The initialize_handle returns a Handle object with an ID. This
-        function should not be called directly
-        :param h1: instance of type "Handle" -> structure: parameter "hid" of
-           type "HandleId" (Handle provides a unique reference that enables
-           access to the data files through functions provided as part of the
-           HandleService. In the case of using shock, the id is the node id.
-           In the case of using shock the value of type is shock. In the
-           future these values should enumerated. The value of url is the
-           http address of the shock server, including the protocol (http or
-           https) and if necessary the port. The values of remote_md5 and
-           remote_sha1 are those computed on the file in the remote data
-           store. These can be used to verify uploads and downloads.),
-           parameter "file_name" of String, parameter "id" of type "NodeId",
-           parameter "type" of String, parameter "url" of String, parameter
-           "remote_md5" of String, parameter "remote_sha1" of String
-        :returns: instance of type "Handle" -> structure: parameter "hid" of
-           type "HandleId" (Handle provides a unique reference that enables
-           access to the data files through functions provided as part of the
-           HandleService. In the case of using shock, the id is the node id.
-           In the case of using shock the value of type is shock. In the
-           future these values should enumerated. The value of url is the
-           http address of the shock server, including the protocol (http or
-           https) and if necessary the port. The values of remote_md5 and
-           remote_sha1 are those computed on the file in the remote data
-           store. These can be used to verify uploads and downloads.),
-           parameter "file_name" of String, parameter "id" of type "NodeId",
-           parameter "type" of String, parameter "url" of String, parameter
-           "remote_md5" of String, parameter "remote_sha1" of String
-        """
-        return self._client.call_method('AbstractHandle.initialize_handle',
-                                        [h1], self._service_ver, context)
-
-    def persist_handle(self, h, context=None):
-        """
-        The persist_handle writes the handle to a persistent store
-        that can be later retrieved using the list_handles
-        function.
-        :param h: instance of type "Handle" -> structure: parameter "hid" of
-           type "HandleId" (Handle provides a unique reference that enables
-           access to the data files through functions provided as part of the
-           HandleService. In the case of using shock, the id is the node id.
-           In the case of using shock the value of type is shock. In the
-           future these values should enumerated. The value of url is the
-           http address of the shock server, including the protocol (http or
-           https) and if necessary the port. The values of remote_md5 and
-           remote_sha1 are those computed on the file in the remote data
-           store. These can be used to verify uploads and downloads.),
-           parameter "file_name" of String, parameter "id" of type "NodeId",
-           parameter "type" of String, parameter "url" of String, parameter
-           "remote_md5" of String, parameter "remote_sha1" of String
+        The persist_handle writes the handle to a persistent store that can be later retrieved using the list_handles function.
+        :param handle: instance of type "Handle" -> structure: parameter
+           "hid" of type "HandleId" (Handle provides a unique reference that
+           enables access to the data files through functions provided as
+           part of the HandleService. In the case of using shock, the id is
+           the node id. In the case of using shock the value of type is
+           shock. In the future these values should enumerated. The value of
+           url is the http address of the shock server, including the
+           protocol (http or https) and if necessary the port. The values of
+           remote_md5 and remote_sha1 are those computed on the file in the
+           remote data store. These can be used to verify uploads and
+           downloads.), parameter "file_name" of String, parameter "id" of
+           type "NodeId", parameter "type" of String, parameter "url" of
+           String, parameter "remote_md5" of String, parameter "remote_sha1"
+           of String
         :returns: instance of String
         """
         return self._client.call_method('AbstractHandle.persist_handle',
-                                        [h], self._service_ver, context)
-
-    def upload(self, infile, context=None):
-        """
-        The upload and download functions  provide an empty
-        implementation that must be provided in a client. If a concrete
-        implementation is not provided an error is thrown. These are
-        the equivelant of abstract methods, with runtime rather than
-        compile time inforcement.
-                
-        [client_implemented]
-        :param infile: instance of String
-        :returns: instance of type "Handle" -> structure: parameter "hid" of
-           type "HandleId" (Handle provides a unique reference that enables
-           access to the data files through functions provided as part of the
-           HandleService. In the case of using shock, the id is the node id.
-           In the case of using shock the value of type is shock. In the
-           future these values should enumerated. The value of url is the
-           http address of the shock server, including the protocol (http or
-           https) and if necessary the port. The values of remote_md5 and
-           remote_sha1 are those computed on the file in the remote data
-           store. These can be used to verify uploads and downloads.),
-           parameter "file_name" of String, parameter "id" of type "NodeId",
-           parameter "type" of String, parameter "url" of String, parameter
-           "remote_md5" of String, parameter "remote_sha1" of String
-        """
-        return self._client.call_method('AbstractHandle.upload',
-                                        [infile], self._service_ver, context)
-
-    def download(self, h, outfile, context=None):
-        """
-        The upload and download functions  provide an empty
-        implementation that must be provided in a client. If a concrete
-        implementation is not provided an error is thrown. These are
-        the equivelant of abstract methods, with runtime rather than
-        compile time inforcement.
-        [client_implemented]
-        :param h: instance of type "Handle" -> structure: parameter "hid" of
-           type "HandleId" (Handle provides a unique reference that enables
-           access to the data files through functions provided as part of the
-           HandleService. In the case of using shock, the id is the node id.
-           In the case of using shock the value of type is shock. In the
-           future these values should enumerated. The value of url is the
-           http address of the shock server, including the protocol (http or
-           https) and if necessary the port. The values of remote_md5 and
-           remote_sha1 are those computed on the file in the remote data
-           store. These can be used to verify uploads and downloads.),
-           parameter "file_name" of String, parameter "id" of type "NodeId",
-           parameter "type" of String, parameter "url" of String, parameter
-           "remote_md5" of String, parameter "remote_sha1" of String
-        :param outfile: instance of String
-        """
-        return self._client.call_method('AbstractHandle.download',
-                                        [h, outfile], self._service_ver, context)
-
-    def upload_metadata(self, h, infile, context=None):
-        """
-        The upload_metadata function uploads metadata to an existing
-        handle. This means that the data that the handle represents
-        has already been uploaded. Uploading meta data before the data
-        has been uploaded is not currently supported.
-        [client_implemented]
-        :param h: instance of type "Handle" -> structure: parameter "hid" of
-           type "HandleId" (Handle provides a unique reference that enables
-           access to the data files through functions provided as part of the
-           HandleService. In the case of using shock, the id is the node id.
-           In the case of using shock the value of type is shock. In the
-           future these values should enumerated. The value of url is the
-           http address of the shock server, including the protocol (http or
-           https) and if necessary the port. The values of remote_md5 and
-           remote_sha1 are those computed on the file in the remote data
-           store. These can be used to verify uploads and downloads.),
-           parameter "file_name" of String, parameter "id" of type "NodeId",
-           parameter "type" of String, parameter "url" of String, parameter
-           "remote_md5" of String, parameter "remote_sha1" of String
-        :param infile: instance of String
-        """
-        return self._client.call_method('AbstractHandle.upload_metadata',
-                                        [h, infile], self._service_ver, context)
-
-    def download_metadata(self, h, outfile, context=None):
-        """
-        The download_metadata function downloads metadata associated
-        with the data handle and writes it to a file.
-        [client_implemented]
-        :param h: instance of type "Handle" -> structure: parameter "hid" of
-           type "HandleId" (Handle provides a unique reference that enables
-           access to the data files through functions provided as part of the
-           HandleService. In the case of using shock, the id is the node id.
-           In the case of using shock the value of type is shock. In the
-           future these values should enumerated. The value of url is the
-           http address of the shock server, including the protocol (http or
-           https) and if necessary the port. The values of remote_md5 and
-           remote_sha1 are those computed on the file in the remote data
-           store. These can be used to verify uploads and downloads.),
-           parameter "file_name" of String, parameter "id" of type "NodeId",
-           parameter "type" of String, parameter "url" of String, parameter
-           "remote_md5" of String, parameter "remote_sha1" of String
-        :param outfile: instance of String
-        """
-        return self._client.call_method('AbstractHandle.download_metadata',
-                                        [h, outfile], self._service_ver, context)
+                                        [handle], self._service_ver, context)
 
     def hids_to_handles(self, hids, context=None):
         """
-        Given a list of handle ids, this function returns
-        a list of handles.
+        Given a list of handle ids, this function returns a list of handles.
+        This method is replaced by fetch_handles_by.
         :param hids: instance of list of type "HandleId" (Handle provides a
            unique reference that enables access to the data files through
            functions provided as part of the HandleService. In the case of
@@ -284,129 +87,11 @@ class AbstractHandle(object):
         return self._client.call_method('AbstractHandle.hids_to_handles',
                                         [hids], self._service_ver, context)
 
-    def are_readable(self, arg_1, context=None):
-        """
-        Given a list of handle ids, this function determines if
-        the underlying data is readable by the caller. If any
-        one of the handle ids reference unreadable data this
-        function returns false.
-        :param arg_1: instance of list of type "HandleId" (Handle provides a
-           unique reference that enables access to the data files through
-           functions provided as part of the HandleService. In the case of
-           using shock, the id is the node id. In the case of using shock the
-           value of type is shock. In the future these values should
-           enumerated. The value of url is the http address of the shock
-           server, including the protocol (http or https) and if necessary
-           the port. The values of remote_md5 and remote_sha1 are those
-           computed on the file in the remote data store. These can be used
-           to verify uploads and downloads.)
-        :returns: instance of Long
-        """
-        return self._client.call_method('AbstractHandle.are_readable',
-                                        [arg_1], self._service_ver, context)
-
-    def is_owner(self, arg_1, context=None):
-        """
-        Given a list of handle ids, this function determines if the underlying
-        data is owned by the caller. If any one of the handle ids reference
-        unreadable data this function returns false.
-        :param arg_1: instance of list of type "HandleId" (Handle provides a
-           unique reference that enables access to the data files through
-           functions provided as part of the HandleService. In the case of
-           using shock, the id is the node id. In the case of using shock the
-           value of type is shock. In the future these values should
-           enumerated. The value of url is the http address of the shock
-           server, including the protocol (http or https) and if necessary
-           the port. The values of remote_md5 and remote_sha1 are those
-           computed on the file in the remote data store. These can be used
-           to verify uploads and downloads.)
-        :returns: instance of Long
-        """
-        return self._client.call_method('AbstractHandle.is_owner',
-                                        [arg_1], self._service_ver, context)
-
-    def is_readable(self, id, context=None):
-        """
-        Given a handle id, this function queries the underlying
-        data store to see if the data being referred to is
-        readable to by the caller.
-        :param id: instance of String
-        :returns: instance of Long
-        """
-        return self._client.call_method('AbstractHandle.is_readable',
-                                        [id], self._service_ver, context)
-
-    def list_handles(self, context=None):
-        """
-        The list function returns the set of handles that were
-        created by the user.
-        :returns: instance of list of type "Handle" -> structure: parameter
-           "hid" of type "HandleId" (Handle provides a unique reference that
-           enables access to the data files through functions provided as
-           part of the HandleService. In the case of using shock, the id is
-           the node id. In the case of using shock the value of type is
-           shock. In the future these values should enumerated. The value of
-           url is the http address of the shock server, including the
-           protocol (http or https) and if necessary the port. The values of
-           remote_md5 and remote_sha1 are those computed on the file in the
-           remote data store. These can be used to verify uploads and
-           downloads.), parameter "file_name" of String, parameter "id" of
-           type "NodeId", parameter "type" of String, parameter "url" of
-           String, parameter "remote_md5" of String, parameter "remote_sha1"
-           of String
-        """
-        return self._client.call_method('AbstractHandle.list_handles',
-                                        [], self._service_ver, context)
-
-    def delete_handles(self, l, context=None):
-        """
-        The delete_handles function takes a list of handles
-        and deletes them on the handle service server.
-        :param l: instance of list of type "Handle" -> structure: parameter
-           "hid" of type "HandleId" (Handle provides a unique reference that
-           enables access to the data files through functions provided as
-           part of the HandleService. In the case of using shock, the id is
-           the node id. In the case of using shock the value of type is
-           shock. In the future these values should enumerated. The value of
-           url is the http address of the shock server, including the
-           protocol (http or https) and if necessary the port. The values of
-           remote_md5 and remote_sha1 are those computed on the file in the
-           remote data store. These can be used to verify uploads and
-           downloads.), parameter "file_name" of String, parameter "id" of
-           type "NodeId", parameter "type" of String, parameter "url" of
-           String, parameter "remote_md5" of String, parameter "remote_sha1"
-           of String
-        """
-        return self._client.call_method('AbstractHandle.delete_handles',
-                                        [l], self._service_ver, context)
-
-    def give(self, user, perm, h, context=None):
-        """
-        :param user: instance of String
-        :param perm: instance of String
-        :param h: instance of type "Handle" -> structure: parameter "hid" of
-           type "HandleId" (Handle provides a unique reference that enables
-           access to the data files through functions provided as part of the
-           HandleService. In the case of using shock, the id is the node id.
-           In the case of using shock the value of type is shock. In the
-           future these values should enumerated. The value of url is the
-           http address of the shock server, including the protocol (http or
-           https) and if necessary the port. The values of remote_md5 and
-           remote_sha1 are those computed on the file in the remote data
-           store. These can be used to verify uploads and downloads.),
-           parameter "file_name" of String, parameter "id" of type "NodeId",
-           parameter "type" of String, parameter "url" of String, parameter
-           "remote_md5" of String, parameter "remote_sha1" of String
-        """
-        return self._client.call_method('AbstractHandle.give',
-                                        [user, perm, h], self._service_ver, context)
-
     def ids_to_handles(self, ids, context=None):
         """
-        Given a list of ids, this function returns
-        a list of handles. In case of Shock, the list of ids
-        are shock node ids and this function the handles, which
-        contains Shock url and related information.
+        Given a list of ids, this function returns a list of handles.
+        In case of Shock, the list of ids are shock node ids.
+        This method is replaced by fetch_handles_by.
         :param ids: instance of list of type "NodeId"
         :returns: instance of list of type "Handle" -> structure: parameter
            "hid" of type "HandleId" (Handle provides a unique reference that
@@ -425,6 +110,148 @@ class AbstractHandle(object):
         """
         return self._client.call_method('AbstractHandle.ids_to_handles',
                                         [ids], self._service_ver, context)
+
+    def fetch_handles_by(self, params, context=None):
+        """
+        This function select records if field column entry is in elements and returns a list of handles.
+        :param params: instance of type "FetchHandlesParams" -> structure:
+           parameter "elements" of list of String, parameter "field_name" of
+           String
+        :returns: instance of list of type "Handle" -> structure: parameter
+           "hid" of type "HandleId" (Handle provides a unique reference that
+           enables access to the data files through functions provided as
+           part of the HandleService. In the case of using shock, the id is
+           the node id. In the case of using shock the value of type is
+           shock. In the future these values should enumerated. The value of
+           url is the http address of the shock server, including the
+           protocol (http or https) and if necessary the port. The values of
+           remote_md5 and remote_sha1 are those computed on the file in the
+           remote data store. These can be used to verify uploads and
+           downloads.), parameter "file_name" of String, parameter "id" of
+           type "NodeId", parameter "type" of String, parameter "url" of
+           String, parameter "remote_md5" of String, parameter "remote_sha1"
+           of String
+        """
+        return self._client.call_method('AbstractHandle.fetch_handles_by',
+                                        [params], self._service_ver, context)
+
+    def is_owner(self, hids, context=None):
+        """
+        Given a list of handle ids, this function determines if the underlying data is owned by the caller.
+        If any one of the handle ids reference unreadable data this function returns false.
+        :param hids: instance of list of type "HandleId" (Handle provides a
+           unique reference that enables access to the data files through
+           functions provided as part of the HandleService. In the case of
+           using shock, the id is the node id. In the case of using shock the
+           value of type is shock. In the future these values should
+           enumerated. The value of url is the http address of the shock
+           server, including the protocol (http or https) and if necessary
+           the port. The values of remote_md5 and remote_sha1 are those
+           computed on the file in the remote data store. These can be used
+           to verify uploads and downloads.)
+        :returns: instance of Long
+        """
+        return self._client.call_method('AbstractHandle.is_owner',
+                                        [hids], self._service_ver, context)
+
+    def delete_handles(self, handles, context=None):
+        """
+        The delete_handles function takes a list of handles and deletes them on the handle service server.
+        :param handles: instance of list of type "Handle" -> structure:
+           parameter "hid" of type "HandleId" (Handle provides a unique
+           reference that enables access to the data files through functions
+           provided as part of the HandleService. In the case of using shock,
+           the id is the node id. In the case of using shock the value of
+           type is shock. In the future these values should enumerated. The
+           value of url is the http address of the shock server, including
+           the protocol (http or https) and if necessary the port. The values
+           of remote_md5 and remote_sha1 are those computed on the file in
+           the remote data store. These can be used to verify uploads and
+           downloads.), parameter "file_name" of String, parameter "id" of
+           type "NodeId", parameter "type" of String, parameter "url" of
+           String, parameter "remote_md5" of String, parameter "remote_sha1"
+           of String
+        :returns: instance of Long
+        """
+        return self._client.call_method('AbstractHandle.delete_handles',
+                                        [handles], self._service_ver, context)
+
+    def are_readable(self, hids, context=None):
+        """
+        Given a list of handle ids, this function determines if the underlying data is readable by the caller.
+        If any one of the handle ids reference unreadable data this function returns false.
+        :param hids: instance of list of type "HandleId" (Handle provides a
+           unique reference that enables access to the data files through
+           functions provided as part of the HandleService. In the case of
+           using shock, the id is the node id. In the case of using shock the
+           value of type is shock. In the future these values should
+           enumerated. The value of url is the http address of the shock
+           server, including the protocol (http or https) and if necessary
+           the port. The values of remote_md5 and remote_sha1 are those
+           computed on the file in the remote data store. These can be used
+           to verify uploads and downloads.)
+        :returns: instance of Long
+        """
+        return self._client.call_method('AbstractHandle.are_readable',
+                                        [hids], self._service_ver, context)
+
+    def is_readable(self, hid, context=None):
+        """
+        Given a handle id, this function queries the underlying data store to see if the data being referred to is readable to by the caller.
+        :param hid: instance of type "HandleId" (Handle provides a unique
+           reference that enables access to the data files through functions
+           provided as part of the HandleService. In the case of using shock,
+           the id is the node id. In the case of using shock the value of
+           type is shock. In the future these values should enumerated. The
+           value of url is the http address of the shock server, including
+           the protocol (http or https) and if necessary the port. The values
+           of remote_md5 and remote_sha1 are those computed on the file in
+           the remote data store. These can be used to verify uploads and
+           downloads.)
+        :returns: instance of Long
+        """
+        return self._client.call_method('AbstractHandle.is_readable',
+                                        [hid], self._service_ver, context)
+
+    def add_read_acl(self, hids, username, context=None):
+        """
+        The add_read_acl function will update the acl of the shock node that the handle references.
+        The function is only accessible to a specific list of users specified at startup time.
+        The underlying shock node will be made readable to the user requested.
+        :param hids: instance of list of type "HandleId" (Handle provides a
+           unique reference that enables access to the data files through
+           functions provided as part of the HandleService. In the case of
+           using shock, the id is the node id. In the case of using shock the
+           value of type is shock. In the future these values should
+           enumerated. The value of url is the http address of the shock
+           server, including the protocol (http or https) and if necessary
+           the port. The values of remote_md5 and remote_sha1 are those
+           computed on the file in the remote data store. These can be used
+           to verify uploads and downloads.)
+        :param username: instance of String
+        :returns: instance of Long
+        """
+        return self._client.call_method('AbstractHandle.add_read_acl',
+                                        [hids, username], self._service_ver, context)
+
+    def set_public_read(self, hids, context=None):
+        """
+        The set_public_read function will update the acl of the shock node that the handle references to make the node globally readable.
+        The function is only accessible to a specific list of users specified at startup time.
+        :param hids: instance of list of type "HandleId" (Handle provides a
+           unique reference that enables access to the data files through
+           functions provided as part of the HandleService. In the case of
+           using shock, the id is the node id. In the case of using shock the
+           value of type is shock. In the future these values should
+           enumerated. The value of url is the http address of the shock
+           server, including the protocol (http or https) and if necessary
+           the port. The values of remote_md5 and remote_sha1 are those
+           computed on the file in the remote data store. These can be used
+           to verify uploads and downloads.)
+        :returns: instance of Long
+        """
+        return self._client.call_method('AbstractHandle.set_public_read',
+                                        [hids], self._service_ver, context)
 
     def status(self, context=None):
         return self._client.call_method('AbstractHandle.status',

--- a/test/DataFileUtil_server_test.py
+++ b/test/DataFileUtil_server_test.py
@@ -284,7 +284,7 @@ class DataFileUtilTest(unittest.TestCase):
         rethandle = ret1['handle']
         hid = rethandle['hid']
         handle = self.hs.hids_to_handles([hid])[0]
-        self.hs.delete_handles([hid])
+        self.hs.delete_handles([handle])
         self.check_handle(rethandle, hid, shock_id,
                           '88d0594a4ee2b25527540fe76233a405', 'input.txt')
         self.check_handle(handle, hid, shock_id,
@@ -844,7 +844,7 @@ class DataFileUtilTest(unittest.TestCase):
         self.delete_shock_node(new_id)
         hid = retcopy['handle']['hid']
         handle = self.hs.hids_to_handles([hid])[0]
-        self.hs.delete_handles([hid])
+        self.hs.delete_handles([handle])
         self.check_handle(retcopy['handle'], hid, new_id,
                           '748ff3bbb8d31783c852513422eedb87', 'input.txt')
         self.check_handle(handle, hid, new_id,
@@ -869,9 +869,9 @@ class DataFileUtilTest(unittest.TestCase):
         # note this is missing fields that the created handles will have
         handle = {'id': str(r1['shock_id']),
                   'type': 'shock',
-                  'url': str(self.shockURL)}
+                  'url': str(self.shockURL),
+                  'file_name': 'ownfile23.txt'}
         handle['hid'] = str(self.hs.persist_handle(handle))
-        handle['file_name'] = None
         handle['remote_md5'] = None
         r2 = self.impl.own_shock_node(
             self.ctx, {'shock_id': r1['shock_id'], 'make_handle': 1})[0]
@@ -1157,7 +1157,8 @@ class DataFileUtilTest(unittest.TestCase):
             {'object_refs': [str(ws) + '/bad_handle'],
              'ignore_errors': 1})[0]['data']
         self.assertIsNone(gret[0])
-        self.hs.delete_handles([handle_id])
+        handle = self.hs.hids_to_handles([handle_id])[0]
+        self.hs.delete_handles([handle])
 
     def test_get_objects_ignore_errors(self):
         objs = [{'name': 'whoop',


### PR DESCRIPTION
@MrCreosote There are 2 tests failed after we deployed new HS2.

1. `delete_handles`: both old HS and HS2 requires a handle object not handle_id for input. Old HS  `delete_handles` is an empty method. That's why it's never got caught. 

2. `persist_handle`: I feel `file_name` should be a required field. But I can change HS2 to make it optional. 