### PR TITLE
Fix 2 test failures due to minor WS error message changes

### DIFF
--- a/lib/DataFileUtil/DataFileUtilServer.py
+++ b/lib/DataFileUtil/DataFileUtilServer.py
@@ -116,7 +116,12 @@ class JSONRPCServiceCustom(JSONRPCService):
             newerr = JSONServerError()
             newerr.trace = traceback.format_exc()
             if len(e.args) == 1:
-                newerr.data = repr(e.args[0])
+                # THIS WAS CHANGED INTENTIONALLY - if you recompile please restore.
+                # repr adds single quotes around string arguments which is not what we want.
+                if type(e.args[0]) == str:
+                    newerr.data = e.args[0]
+                else:
+                    newerr.data = repr(e.args[0])
             else:
                 newerr.data = repr(e.args)
             raise newerr

--- a/test/DataFileUtil_server_test.py
+++ b/test/DataFileUtil_server_test.py
@@ -1032,7 +1032,7 @@ class DataFileUtilTest(unittest.TestCase):
                                              }
                                             ]
                                 },
-                               'Object 1, foo, has no data',
+                               'Object #1, foo: no data',
                                exception=WorkspaceError)
 
     def test_save_objects_with_extra_prov_refs(self):
@@ -1168,7 +1168,7 @@ class DataFileUtilTest(unittest.TestCase):
                          ]
              })[0][0]
         self.delete_shock_node(ret1['shock_id'])
-        err = 'The Handle Manager reported a problem while attempting to set Handle ACLs'
+        err = 'The Handle Service reported a problem while attempting to set Handle ACLs'
         self.fail_get_objects({'object_refs': [str(ws) + '/bad_handle']},
                               err, exception=HandleError)
 


### PR DESCRIPTION
Minor wording changes in workspace error messages caused a couple of tests to break.

Google drive tests are still failing; those are way out of scope for this PR.