### PR TITLE
Fix build and tests

### DIFF
--- a/.github/workflows/kb_sdk_test.yaml
+++ b/.github/workflows/kb_sdk_test.yaml
@@ -50,8 +50,10 @@ jobs:
     - name: Run tests
       if: "!contains(github.event.head_commit.message, 'skip ci')"
       shell: bash
-      env:
-        CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
       run: |
         sh $GITHUB_WORKSPACE/kb_sdk_actions/bin/kb-sdk test
-        bash <(curl -s https://codecov.io/bash)
+
+    - name: Upload coverage to Codecov
+      uses: codecov/codecov-action@v3
+      with:
+        fail_ci_if_error: true

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@ test_local
 sdk.cfg
 /run_local/
 *.py.bak-*
+/.settings/
+/.project
+/.pydevproject

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,24 +1,28 @@
-FROM kbase/sdkbase2:python
+FROM kbase/sdkpython:3.8.10
 MAINTAINER KBase Developer
 # -----------------------------------------
 
 # Insert apt-get instructions here to install
 # any required dependencies for your module.
 
-# RUN apt-get update
+RUN apt update
 
-RUN pip install semver \
-    && ( [ $(pip show filemagic|grep -c filemagic) -eq 0 ] || pip uninstall -y filemagic ) \
-    && pip install python-magic \
-    && pip install ftputil \
-    && pip install ipython==5.3.0 \
-    && pip install pyftpdlib==1.5.6 \
-    && sudo apt-get install nano
+RUN apt install -y nano pigz wget libmagic-dev
+
+RUN pip uninstall -y filemagic
+
+# bz2file hasn't been updated in 10 years
+RUN pip install \
+    requests==2.31.0 \
+    requests_toolbelt==1.0.0 \
+    semver==3.0.2 \
+    python-magic==0.4.27 \
+    ftputil==5.1.0 \
+    ipython==5.3.0 \
+    bz2file==0.98 \
+    pyftpdlib==1.5.6
+
 # -----------------------------------------
-
-RUN sudo apt-get update
-RUN sudo apt-get install pigz wget
-RUN pip install bz2file
 
 COPY ./ /kb/module
 RUN mkdir -p /kb/module/work

--- a/Makefile
+++ b/Makefile
@@ -53,8 +53,7 @@ build-test-script:
 	echo 'export KB_AUTH_TOKEN=`cat /kb/module/work/token`' >> $(TEST_DIR)/$(TEST_SCRIPT_NAME)
 	echo 'export PYTHONPATH=$$script_dir/../$(LIB_DIR):$$PATH:$$PYTHONPATH' >> $(TEST_DIR)/$(TEST_SCRIPT_NAME)
 	echo 'cd $$script_dir/../$(TEST_DIR)' >> $(TEST_DIR)/$(TEST_SCRIPT_NAME)
-	echo 'python -u -m unittest discover -p "*_test.py"' >> $(TEST_DIR)/$(TEST_SCRIPT_NAME)
-	echo 'python -m nose --with-coverage --cover-package=$(SERVICE_CAPS) --cover-html --cover-html-dir=/kb/module/work/test_coverage --cover-xml --cover-xml-file=/kb/module/work/test_coverage/coverage.xml --nocapture  --nologcapture .' >> $(TEST_DIR)/$(TEST_SCRIPT_NAME)
+	echo 'python -m nose --with-coverage --cover-package=$(SERVICE_CAPS) --cover-html --cover-html-dir=/kb/module/work/test_coverage --cover-xml --cover-xml-file=/kb/module/work/test_coverage/coverage.xml .' >> $(TEST_DIR)/$(TEST_SCRIPT_NAME)
 	chmod +x $(TEST_DIR)/$(TEST_SCRIPT_NAME)
 
 test:

--- a/test/DataFileUtil_server_test.py
+++ b/test/DataFileUtil_server_test.py
@@ -512,7 +512,7 @@ class DataFileUtilTest(unittest.TestCase):
         os.chdir(wd)
         self.assertEqual(ret1['node_file_name'], 'target.tar.gz')
         self.assertGreater(ret1['size'], 220)
-        self.assertLess(ret1['size'], 240)
+        self.assertLess(ret1['size'], 260)
         shock_id = ret1['shock_id']
         file_path2 = os.path.join(tmp_dir, 'output.tgz')
         ret2 = self.impl.shock_to_file(
@@ -523,7 +523,7 @@ class DataFileUtilTest(unittest.TestCase):
         self.assertIsNone(ret2['attributes'])
         self.assertEqual(ret2['file_path'], file_path2)
         self.assertGreater(ret2['size'], 220)
-        self.assertLess(ret2['size'], 240)
+        self.assertLess(ret2['size'], 260)
         with tarfile.open(file_path2) as t:
             self.assertEqual(set(t.getnames()),
                              set(['.', './intar1.txt', './intar2.txt']))
@@ -569,7 +569,7 @@ class DataFileUtilTest(unittest.TestCase):
              'pack': 'targz'})[0]
         self.assertEqual(ret1['node_file_name'], 'tartest2.tar.gz')
         self.assertGreater(ret1['size'], 220)
-        self.assertLess(ret1['size'], 240)
+        self.assertLess(ret1['size'], 260)
         shock_id = ret1['shock_id']
         file_path2 = os.path.join(tmp_dir, 'output.tgz')
         ret2 = self.impl.shock_to_file(
@@ -580,7 +580,7 @@ class DataFileUtilTest(unittest.TestCase):
         self.assertIsNone(ret2['attributes'])
         self.assertEqual(ret2['file_path'], file_path2)
         self.assertGreater(ret1['size'], 220)
-        self.assertLess(ret1['size'], 240)
+        self.assertLess(ret1['size'], 260)
         with tarfile.open(file_path2) as t:
             self.assertEqual(set(t.getnames()),
                              set(['.', './intar1.txt', './intar2.txt']))
@@ -1671,8 +1671,8 @@ class DataFileUtilTest(unittest.TestCase):
 
     def test_download_google_drive_link_uncompress_file(self):
         # google drive link of 'file1.txt'
-        file_url = 'https://drive.google.com/open?'
-        file_url += 'id=0B0exSa7ebQ0qX01mZ3FaRzhuMDQ'
+        file_url = ("https://drive.google.com/open?id=0B0exSa7ebQ0qX01mZ3FaRzhuMDQ"
+                    + "&resourcekey=0-eeP2JBzYnbKaFVncybSA0Q")
         params = {
             'download_type': 'Google Drive',
             'file_url': file_url
@@ -1687,8 +1687,8 @@ class DataFileUtilTest(unittest.TestCase):
 
     def test_download_google_drive_link_compress_file(self):
         # google drive link of 'file1.txt.gzip'
-        file_url = 'https://drive.google.com/file/d/'
-        file_url += '0B0exSa7ebQ0qU1U5YmxMRktkbmc/view?usp=sharing'
+        file_url = ("https://drive.google.com/file/d/0B0exSa7ebQ0qU1U5YmxMRktkbmc"
+                    + "/view?usp=drive_link&resourcekey=0-YXZfeTbInLOV0hkGVx92AA")
         params = {
             'download_type': 'Google Drive',
             'file_url': file_url
@@ -1702,7 +1702,7 @@ class DataFileUtilTest(unittest.TestCase):
                          os.stat(ret1['copy_file_path']).st_size)
 
     def test_download_google_drive_link_large_uncompress_file(self):
-        file_url = 'https://drive.google.com/open?id=1WBni9AcU7AHWY72amXBg7Dxb0d2RUGch'
+        file_url = "https://drive.google.com/open?id=1WBni9AcU7AHWY72amXBg7Dxb0d2RUGch"
         params = {
             'download_type': 'Google Drive',
             'file_url': file_url
@@ -1717,8 +1717,8 @@ class DataFileUtilTest(unittest.TestCase):
 
     def test_download_google_drive_link_archive_file(self):
         # google drive link of 'zip1.zip'
-        file_url = 'https://drive.google.com/open?'
-        file_url += 'id=0B0exSa7ebQ0qcEhRaDJoVDJSTkk'
+        file_url = ("https://drive.google.com/file/d/0B0exSa7ebQ0qcEhRaDJoVDJSTkk"
+                    + "/view?usp=drive_link&resourcekey=0-wTnouG2x1Yb0bUm08rG1KA")
         params = {
             'download_type': 'Google Drive',
             'file_url': file_url

--- a/test/test_retrieve_filename.py
+++ b/test/test_retrieve_filename.py
@@ -69,3 +69,23 @@ class RetrieveFilenameTest(unittest.TestCase):
         expected_fn = given_fn[0:255]
         fn = retrieve_filename(url)
         self.assertEqual(fn, expected_fn)
+        
+    def test_filename_google(self):
+        """
+        Test a google downloaded file, which has a different content disposition header
+        than box.com and broke an older implementation of the header parser.
+        """
+        url = "https://docs.google.com/uc?export=download&id=1iPE1Mw6m91ONfm-Z4WpxDGTXX_BKADH8"
+        expected_filename = "Sample1.fastq.gz"
+        fn = retrieve_filename(url)
+        self.assertEqual(fn, expected_filename)
+
+    @unittest.skip("Eventually redirects to a 200 auth page. Need to do something very different")
+    def test_filename_google_inaccessible(self):
+        """
+        Test a non-public google downloaded file
+        """
+        url = "https://docs.google.com/uc?export=download&id=197Bp6PuiEiuCvOUulvo8jQiiv2bhQj9o"
+        expected_filename = "Sample1.fastq.gz"
+        fn = retrieve_filename(url)
+        self.assertEqual(fn, expected_filename)


### PR DESCRIPTION
Google downloads seem to work now anyway, given up to date urls retrieved from google drive. The lesson to be learned here is use libraries rather than fragile string parsing. To that end, we should probably use an actual Google drive client rather than the hack I've got working for now

Also stop running tests twice, which has been happening for 4 years apparently