### PR TITLE
Fix Blobstore failure response

### DIFF
--- a/.github/workflows/kb_sdk_test.yaml
+++ b/.github/workflows/kb_sdk_test.yaml
@@ -2,27 +2,24 @@ name: KBase SDK Tests
 
 on:
   push:
-    branches: [ master ]
+    branches:
+    - master
+    - main
   pull_request:
-    branches: [ master ]
+    branches:
+    - master
+    - main
+    - develop
 
 jobs:
 
   sdk_tests:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
 
     - name: Check out GitHub repo
       if: "!contains(github.event.head_commit.message, 'skip ci')"
       uses: actions/checkout@v2
-
-    - name: Check out Actions CI files
-      if: "!contains(github.event.head_commit.message, 'skip ci')"
-      uses: actions/checkout@v2
-      with:
-        repository: 'kbaseapps/kb_sdk_actions'
-        path: 'kb_sdk_actions'
-
 
     - name: Set up test environment
       if: "!contains(github.event.head_commit.message, 'skip ci')"
@@ -30,12 +27,7 @@ jobs:
       env:
         KBASE_TEST_TOKEN: ${{ secrets.KBASE_TEST_TOKEN }}
       run: |
-        # Verify kb_sdk_actions clone worked
-        test -f "$HOME/kb_sdk_actions/bin/kb-sdk" && echo "CI files cloned"
-        # Pull kb-sdk & create startup script
-        docker pull kbase/kb-sdk
-       
-        sh $GITHUB_WORKSPACE/kb_sdk_actions/bin/make_testdir && echo "Created test_local"
+        sh GHA_scripts/make_testdir && echo "Created test_local"
         test -f "test_local/test.cfg" && echo "Confirmed config exists"
 
     - name: Configure authentication
@@ -51,9 +43,9 @@ jobs:
       if: "!contains(github.event.head_commit.message, 'skip ci')"
       shell: bash
       run: |
-        sh $GITHUB_WORKSPACE/kb_sdk_actions/bin/kb-sdk test
+        sh GHA_scripts/kb-sdk test --verbose
 
     - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v3
+      uses: codecov/codecov-action@v4
       with:
         fail_ci_if_error: true

--- a/.github/workflows/kb_sdk_test.yaml
+++ b/.github/workflows/kb_sdk_test.yaml
@@ -48,4 +48,5 @@ jobs:
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v4
       with:
+        token: ${{ secrets.CODECOV_TOKEN }}
         fail_ci_if_error: true

--- a/GHA_scripts/kb-sdk
+++ b/GHA_scripts/kb-sdk
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+# TODO may want to make the image an env var or argument
+
+# See https://github.com/kbaseapps/kb_sdk_actions/blob/master/bin/kb-sdk for source
+
+# Cache the group for the docker file
+if [ ! -e $HOME/.kbsdk.cache ] ; then
+  docker run -i -v /var/run/docker.sock:/var/run/docker.sock --entrypoint ls ghcr.io/kbase/kb_sdk_patch-develop:br-0.0.4 -l /var/run/docker.sock|awk '{print $4}' > $HOME/.kbsdk.cache
+fi
+
+exec docker run -i --rm -v $HOME:$HOME -w $(pwd) -v /var/run/docker.sock:/var/run/docker.sock -e DSHELL=$SHELL --group-add $(cat $HOME/.kbsdk.cache) ghcr.io/kbase/kb_sdk_patch-develop:br-0.0.4 $@

--- a/GHA_scripts/make_testdir
+++ b/GHA_scripts/make_testdir
@@ -1,0 +1,16 @@
+#!/bin/sh
+
+# TODO may want to make the image an env var or argument
+
+# See https://github.com/kbaseapps/kb_sdk_actions/blob/master/bin/make_testdir for source
+
+# Disable the default `return 1` when creating `test_local`
+set +e
+
+# Cache the group for the docker file
+if [ ! -e $HOME/.kbsdk.cache ] ; then
+  docker run -i -v /var/run/docker.sock:/var/run/docker.sock --entrypoint ls ghcr.io/kbase/kb_sdk_patch-develop:br-0.0.4 -l /var/run/docker.sock|awk '{print $4}' > $HOME/.kbsdk.cache
+fi
+
+exec docker run -i --rm -v $HOME:$HOME -u $(id -u) -w $(pwd) -v /var/run/docker.sock:/var/run/docker.sock  -e DUSER=$USER -e DSHELL=$SHELL --group-add $(cat $HOME/.kbsdk.cache) ghcr.io/kbase/kb_sdk_patch-develop:br-0.0.4 test
+exit

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,9 @@
+# 0.2.2
+
+- Fixed a bug where if the Blobstore returned an non-json response, logging the response would
+  fail due to attempting to concatenate string and binary types. This would shadow the real
+  error returned from the Blobstore.
+
 # 0.2.1
 
 - fixed several bugs regarding downloading files from Google Drive. How long the current method

--- a/kbase.yml
+++ b/kbase.yml
@@ -8,7 +8,7 @@ service-language:
     python
 
 module-version:
-    0.2.1
+    0.2.2
 
 owners:
     [gaprice, scanon, tgu2]

--- a/lib/DataFileUtil/DataFileUtilClient.py
+++ b/lib/DataFileUtil/DataFileUtilClient.py
@@ -205,8 +205,10 @@ class DataFileUtil(object):
            String, parameter "unpack" of String
         :returns: instance of list of type "UnpackFilesResult" (Output
            parameters for the unpack_files function. file_path - the path to
-           the unpacked file, or in the case of archive files, the path to
-           the original archive file.) -> structure: parameter "file_path" of
+           either a) the unpacked file or b) in the case of archive files,
+           the path to the original archive file, possibly uncompressed, or
+           c) in the case of regular files that don't need processing, the
+           path to the input file.) -> structure: parameter "file_path" of
            String
         """
         return self._client.run_job('DataFileUtil.unpack_files',

--- a/test/DataFileUtil_server_test.py
+++ b/test/DataFileUtil_server_test.py
@@ -105,7 +105,7 @@ class DataFileUtilTest(unittest.TestCase):
         header = {'Authorization': 'Oauth {0}'.format(cls.token)}
         requests.delete(cls.shockURL + '/node/' + node_id, headers=header,
                         allow_redirects=True)
-        print(('Deleted shock node ' + node_id))
+        print(('Deleted Blobstore node ' + node_id))
 
     def test_file_to_shock_and_back_by_handle(self):
         input_ = "Test!!!"
@@ -723,7 +723,7 @@ class DataFileUtilTest(unittest.TestCase):
     def test_upload_err_no_file_provided(self):
         self.fail_upload(
             {'file_path': ''},
-            'No file\(s\) provided for upload to Shock')
+            'No file\(s\) provided for upload to the Blobstore')
 
     def test_upload_err_bad_pack_param(self):
         self.fail_upload(
@@ -918,7 +918,7 @@ class DataFileUtilTest(unittest.TestCase):
             {'shock_id': '79261fd9-ae10-4a84-853d-1b8fcd57c8f23',
              'file_path': 'foo'
              },
-            'Error downloading file from shock node ' +
+            'Error downloading file from Blobstore node ' +
             '79261fd9-ae10-4a84-853d-1b8fcd57c8f23: Node not found',
             exception=ShockException)
     
@@ -927,7 +927,7 @@ class DataFileUtilTest(unittest.TestCase):
             {'shock_id': '',
              'file_path': 'foo'
              },
-            'Must provide shock ID or handle ID')
+            'Must provide Blobstore ID or handle ID')
 
     def test_download_err_no_file_provided(self):
         self.fail_download(
@@ -994,14 +994,14 @@ class DataFileUtilTest(unittest.TestCase):
     def test_copy_err_node_not_found(self):
         self.fail_copy(
             {'shock_id': '79261fd9-ae10-4a84-853d-1b8fcd57c8f23'},
-            'Error copying Shock node ' +
+            'Error copying Blobstore node ' +
             '79261fd9-ae10-4a84-853d-1b8fcd57c8f23: ' +
             'Invalid copy_data: invalid UUID length: 37',
             exception=ShockException)
 
     def test_copy_err_no_node_provided(self):
         self.fail_copy(
-            {'shock_id': ''}, 'Must provide shock ID')
+            {'shock_id': ''}, 'Must provide Blobstore ID')
 
     def test_own_node_owned_with_existing_handle(self):
         fp = self.write_file('ownfile23.txt', 'ownfile23')
@@ -1080,13 +1080,13 @@ class DataFileUtilTest(unittest.TestCase):
     def test_own_err_node_not_found(self):
         self.fail_own(
             {'shock_id': '79261fd9-ae10-4a84-853d-1b8fcd57c8f23'},
-            'Error getting ACLs for Shock node ' +
+            'Error getting ACLs for Blobstore node ' +
             '79261fd9-ae10-4a84-853d-1b8fcd57c8f23: Node not found',
             exception=ShockException)
 
     def test_own_err_no_node_provided(self):
         self.fail_own(
-            {'shock_id': ''}, 'Must provide shock ID')
+            {'shock_id': ''}, 'Must provide Blobstore ID')
 
     def test_translate_ws_name(self):
         self.assertEqual(self.impl.ws_name_to_id(self.ctx, self.ws_info[1])[0],


### PR DESCRIPTION
Fixed a bug where if the Blobstore returned an non-json response, logging the response would fail due to attempting to concatenate string and binary types. This would shadow the real error returned from the Blobstore.

Also changed a few Shock references to Blobstore. Baby steps.